### PR TITLE
OpenAPI interpreter

### DIFF
--- a/herald.cabal
+++ b/herald.cabal
@@ -8,31 +8,34 @@ maintainer: i.am.tom.harding@gmail.com
 category: Data
 build-type: Simple
 
-library
+common libraries
   build-depends:
     , aeson
     , base
     , containers
+    , free
+    , mtl
+    , lens
     , scientific
+    , openapi3
     , text
     , vector
+
+library
+  import: libraries
   default-language: GHC2021
   exposed-modules:
     Herald.Schema
+    Herald.OpenAPI
   ghc-options: -Wall -Wextra -Wunused-packages
   hs-source-dirs: source
 
 test-suite herald
+  import: libraries
   build-depends:
-    , aeson
-    , base
-    , containers
     , hspec
-    , scientific
     , tasty
     , tasty-hspec
-    , text
-    , vector
   build-tool-depends:
    tasty-discover:tasty-discover
   default-language: GHC2021
@@ -42,6 +45,8 @@ test-suite herald
     tests
   main-is: Driver.hs
   other-modules:
+    Herald.OpenAPI
+    Herald.OpenAPITest
     Herald.Schema
     Herald.SchemaTest
   type: exitcode-stdio-1.0

--- a/herald.cabal
+++ b/herald.cabal
@@ -14,7 +14,6 @@ common libraries
     , base
     , containers
     , free
-    , mtl
     , lens
     , scientific
     , openapi3

--- a/source/Herald/OpenAPI.hs
+++ b/source/Herald/OpenAPI.hs
@@ -1,0 +1,113 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE UnicodeSyntax #-}
+
+module Herald.OpenAPI where
+
+import Control.Alternative.Free (Alt (Alt), AltF (Ap, Pure))
+import Control.Lens
+import Data.Aeson (Array, Object, ToJSON (toJSON))
+import Data.Kind (Constraint, Type)
+import Data.Map.Strict qualified as Map
+import Data.OpenApi qualified as OA
+import Data.Scientific (Scientific)
+import Data.Set (Set)
+import Data.String (fromString)
+import Data.Text (Text)
+import GHC.Exts (fromList)
+import Herald.Schema (Expr, Schema)
+import Herald.Schema qualified as Schema
+
+document ∷ Schema Alt x → OA.Schema
+document structure = go structure mempty
+  where
+    go ∷ Schema Alt x → OA.Schema → OA.Schema
+    go structure' acc = case structure' of
+      Schema.Nullable s → go       s acc & OA.nullable ?~ True
+      Schema.Array    s → branches s acc & OA.type_    ?~ OA.OpenApiArray
+      Schema.Boolean  s → branches s acc & OA.type_    ?~ OA.OpenApiBoolean
+      Schema.Number   s → branches s acc & OA.type_    ?~ OA.OpenApiNumber
+      Schema.Object   s → branches s acc & OA.type_    ?~ OA.OpenApiObject
+      Schema.String   s → branches s acc & OA.type_    ?~ OA.OpenApiString
+
+    branches ∷ ∀ s i o. Document i ⇒ Expr Alt s i o → OA.Schema → OA.Schema
+    branches = \case
+      Alt [     ] → id
+      Alt [choix] → unwrap choix
+      Alt choices → OA.oneOf ?~ [ OA.Inline (unwrap c mempty) | c ← choices ]
+
+    unwrap ∷ ∀ s i o. Document i ⇒ AltF (Schema.ExprF Alt s i) o → OA.Schema → OA.Schema
+    unwrap = \case
+      Pure _ → id
+      Ap x f → branches f . expr x
+
+    rejected ∷ ∀ i. Document i ⇒ Set i → OA.Referenced OA.Schema
+    rejected = OA.Inline . flip expr mempty . Schema.Allow . Map.fromSet \_ → ()
+
+    expr ∷ ∀ s i o. Document i ⇒ Schema.ExprF Alt s i o → OA.Schema → OA.Schema
+    expr = \case
+      Schema.Allow       values → OA.enum_       ?~ map toJSON (Map.keys values)
+      Schema.Forbid      values → OA.not_        ?~ rejected values
+      Schema.Deprecated         → OA.deprecated  ?~ True
+      Schema.Description text   → OA.description ?~ text
+      Schema.Example     value  → OA.example     ?~ toJSON value
+      Schema.Title       text   → OA.title       ?~ text
+      Schema.Command     inner  → typed_ inner
+      Schema.Value              → id
+
+type Document ∷ Type → Constraint
+class ToJSON input ⇒ Document input where
+  typed_ ∷ ∀ x. Schema.Command Alt input x → OA.Schema → OA.Schema
+
+instance Document Bool where
+  typed_ = \case
+
+instance Document Array where
+  typed_ = \case
+    Schema.MaxItems    count → OA.maxItems    ?~ fromIntegral count
+    Schema.MinItems    count → OA.maxItems    ?~ fromIntegral count
+    Schema.UniqueItems       → OA.uniqueItems ?~ True
+    Schema.Items       items → OA.items       ?~ OA.OpenApiItemsArray [OA.Inline (document items)]
+
+instance Document Scientific where
+  typed_ = \case
+    Schema.Maximum          count  → OA.maximum_         ?~ count
+    Schema.Minimum          count  → OA.minimum_         ?~ count
+    Schema.ExclusiveMaximum        → OA.exclusiveMaximum ?~ True
+    Schema.ExclusiveMinimum        → OA.exclusiveMinimum ?~ True
+    Schema.MultipleOf       factor → OA.multipleOf       ?~ factor
+
+    Schema.Double  → \x → x & OA.type_ ?~ OA.OpenApiNumber  & OA.format ?~ "double"
+    Schema.Float   → \x → x & OA.type_ ?~ OA.OpenApiNumber  & OA.format ?~ "float"
+    Schema.Int32   → \x → x & OA.type_ ?~ OA.OpenApiInteger & OA.format ?~ "int32"
+    Schema.Int64   → \x → x & OA.type_ ?~ OA.OpenApiInteger & OA.format ?~ "int64"
+    Schema.Integer → \x → x & OA.type_ ?~ OA.OpenApiInteger
+
+instance Document Object where
+  typed_ = \case
+    Schema.ReadOnly            → OA.readOnly       ?~ True
+    Schema.WriteOnly           → OA.writeOnly      ?~ True
+    Schema.MaxProperties count → OA.maxProperties  ?~ fromIntegral count
+    Schema.MinProperties count → OA.minProperties  ?~ fromIntegral count
+    Schema.Required  key value → \x → x & OA.required <>~ [key] & OA.properties <>~ fromList [( key, OA.Inline (document value) )]
+    Schema.Optional  key value → OA.properties <>~ fromList [( key, OA.Inline (document value) )]
+
+    Schema.AdditionalProperties constraint →
+      OA.additionalProperties ?~ case constraint of
+        Just inner → OA.AdditionalPropertiesSchema (OA.Inline (document inner))
+        Nothing    → OA.AdditionalPropertiesAllowed True
+
+instance Document Text where
+  typed_ = \case
+    Schema.MaxLength count  → OA.maxLength ?~ fromIntegral count
+    Schema.MinLength count  → OA.minLength ?~ fromIntegral count
+    Schema.Pattern   string → OA.pattern   ?~ fromString string
+    Schema.Format    format → OA.format    ?~ case format of
+      Schema.Byte     → "byte"
+      Schema.Binary   → "binary"
+      Schema.Date     → "date"
+      Schema.DateTime → "date-time"
+      Schema.Password → "password"
+      Schema.Custom x → x

--- a/source/Herald/Schema.hs
+++ b/source/Herald/Schema.hs
@@ -1,15 +1,18 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UnicodeSyntax #-}
 
 module Herald.Schema where
 
+import Control.Alternative.Free (Alt, liftAlt)
 import Data.Aeson (Array, Object)
 import Data.Aeson.KeyMap (KeyMap)
 import Data.Kind (Type)
 import Data.Map.Strict (Map)
 import Data.Scientific (Scientific)
 import Data.Set (Set)
+import Data.String (IsString (fromString))
 import Data.Text (Text)
 import Data.Vector (Vector)
 import Numeric.Natural (Natural)
@@ -25,6 +28,24 @@ data Schema f x where
   Object ∷ Expr f switch Object x → Schema f x
   String ∷ Expr f switch Text x → Schema f x
 
+nullable ∷ ∀ f x. Schema f x → Schema f (Maybe x)
+nullable = Nullable
+
+array ∷ ∀ f s x. Expr f s Array x → Schema f x
+array = Array
+
+boolean ∷ ∀ f s x. Expr f s Bool x → Schema f x
+boolean = Boolean
+
+number ∷ ∀ f s x. Expr f s Scientific x → Schema f x
+number = Number
+
+object ∷ ∀ f s x. Expr f s Object x → Schema f x
+object = Object
+
+string ∷ ∀ f s x. Expr f s Text x → Schema f x
+string = String
+
 type Expr ∷ ((Type → Type) → (Type → Type)) → Switch → Type → Type → Type
 type Expr f switch input = f (ExprF f switch input)
 
@@ -34,13 +55,37 @@ data Switch = Enumerate | Constrain
 type ExprF ∷ ((Type → Type) → (Type → Type)) → Switch → Type → Type → Type
 data ExprF f switch input output where
   Command ∷ Command f input output → ExprF f 'Constrain input output
-  Deprecate ∷ ExprF f switch input ()
+  Deprecated ∷ ExprF f switch input ()
   Description ∷ Text → ExprF f switch input ()
+  Example ∷ input → ExprF f switch input ()
   Allow ∷ Map input output → ExprF f 'Enumerate input output
   Forbid ∷ Set input → ExprF f 'Constrain input ()
-  Name ∷ Text → ExprF f switch input ()
   Title ∷ Text → ExprF f switch input ()
   Value ∷ ExprF f switch input input
+
+allow ∷ ∀ i o. Map i o → Expr Alt 'Enumerate i o
+allow = liftAlt . Allow
+
+forbid ∷ ∀ i. Set i → Expr Alt 'Constrain i ()
+forbid = liftAlt . Forbid
+
+command ∷ ∀ i o. Command Alt i o → Expr Alt 'Constrain i o
+command = liftAlt . Command
+
+deprecated ∷ ∀ s i. Expr Alt s i ()
+deprecated = liftAlt Deprecated
+
+description ∷ ∀ s i. Text → Expr Alt s i ()
+description = liftAlt . Description
+
+example ∷ ∀ s i. i → Expr Alt s i ()
+example = liftAlt . Example
+
+title ∷ ∀ s i. Text → Expr Alt s i ()
+title = liftAlt . Title
+
+value ∷ ∀ s i. Expr Alt s i i
+value = liftAlt Value
 
 type Command ∷ ((Type → Type) → (Type → Type)) → Type → Type → Type
 data family Command f input
@@ -50,6 +95,18 @@ data instance Command f Array x where
   MaxItems ∷ Natural → Command f Array ()
   MinItems ∷ Natural → Command f Array ()
   UniqueItems ∷ Command f Array ()
+
+items ∷ ∀ x. Schema Alt x → Expr Alt 'Constrain Array (Vector x)
+items = command . Items
+
+maxItems ∷ Natural → Expr Alt 'Constrain Array ()
+maxItems = command . MaxItems
+
+minItems ∷ Natural → Expr Alt 'Constrain Array ()
+minItems = command . MinItems
+
+uniqueItems ∷ Expr Alt 'Constrain Array ()
+uniqueItems = command UniqueItems
 
 data instance Command f Bool _
 
@@ -65,8 +122,35 @@ data instance Command f Scientific x where
   Minimum ∷ Scientific → Command f Scientific ()
   MultipleOf ∷ Scientific → Command f Scientific ()
 
-type Inclusivity ∷ Type
-data Inclusivity = Exclusive | Inclusive
+double ∷ Expr Alt 'Constrain Scientific Double
+double = command Double
+
+float ∷ Expr Alt 'Constrain Scientific Float
+float = command Float
+
+int32 ∷ Expr Alt 'Constrain Scientific Int32
+int32 = command Int32
+
+int64 ∷ Expr Alt 'Constrain Scientific Int64
+int64 = command Int64
+
+integer ∷ ∀ i. (Bounded i, Integral i) ⇒ Expr Alt 'Constrain Scientific i
+integer = command Integer
+
+exclusiveMaximum ∷ Expr Alt 'Constrain Scientific ()
+exclusiveMaximum = command ExclusiveMaximum
+
+exclusiveMinimum ∷ Expr Alt 'Constrain Scientific ()
+exclusiveMinimum = command ExclusiveMinimum
+
+maximum ∷ Scientific → Expr Alt 'Constrain Scientific ()
+maximum = command . Maximum
+
+minimum ∷ Scientific → Expr Alt 'Constrain Scientific ()
+minimum = command . Minimum
+
+multipleOf ∷ Scientific → Expr Alt 'Constrain Scientific ()
+multipleOf = command . MultipleOf
 
 data instance Command f Object x where
   Required ∷ Text → Schema f x → Command f Object x
@@ -75,7 +159,28 @@ data instance Command f Object x where
   WriteOnly ∷ Command f Object ()
   MaxProperties ∷ Natural → Command f Object ()
   MinProperties ∷ Natural → Command f Object ()
-  AdditionalProperties ∷ Schema f x → Command f Object (KeyMap x)
+  AdditionalProperties ∷ Maybe (Schema f x) → Command f Object (KeyMap x)
+
+required ∷ ∀ x. Text → Schema Alt x → Expr Alt 'Constrain Object x
+required key = command . Required key
+
+optional ∷ ∀ x. Text → Schema Alt x → Expr Alt 'Constrain Object (Maybe x)
+optional key = command . Optional key
+
+readOnly ∷ Expr Alt 'Constrain Object ()
+readOnly = command ReadOnly
+
+writeOnly ∷ Expr Alt 'Constrain Object ()
+writeOnly = command WriteOnly
+
+maxProperties ∷ Natural → Expr Alt 'Constrain Object ()
+maxProperties = command . MaxProperties
+
+minProperties ∷ Natural → Expr Alt 'Constrain Object ()
+minProperties = command . MinProperties
+
+additionalProperties ∷ ∀ x. Maybe (Schema Alt x) → Expr Alt 'Constrain Object (KeyMap x)
+additionalProperties = command . AdditionalProperties
 
 data instance Command f Text x where
   MaxLength ∷ Natural → Command f Text ()
@@ -83,5 +188,41 @@ data instance Command f Text x where
   Format ∷ Format → Command f Text ()
   Pattern ∷ String → Command f Text ()
 
+maxLength ∷ Natural → Expr Alt 'Constrain Text ()
+maxLength = command . MaxLength
+
+minLength ∷ Natural → Expr Alt 'Constrain Text ()
+minLength = command . MinLength
+
+format ∷ Format → Expr Alt 'Constrain Text ()
+format = command . Format
+
+pattern ∷ String → Expr Alt 'Constrain Text ()
+pattern = command . Pattern
+
 type Format ∷ Type
 data Format = Date | DateTime | Password | Byte | Binary | Custom Text
+
+date ∷ Format
+date = Date
+
+dateTime ∷ Format
+dateTime = DateTime
+
+password ∷ Format
+password = Password
+
+byte ∷ Format
+byte = Byte
+
+binary ∷ Format
+binary = Binary
+
+instance IsString Format where
+  fromString = \case
+    "date"      → Date
+    "date-time" → DateTime
+    "password"  → Password
+    "byte"      → Byte
+    "binary"    → Binary
+    anything    → Custom (fromString anything)

--- a/tests/Herald/OpenAPITest.hs
+++ b/tests/Herald/OpenAPITest.hs
@@ -1,0 +1,124 @@
+{-# LANGUAGE ApplicativeDo #-}
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE UnicodeSyntax #-}
+
+module Herald.OpenAPITest where
+
+import Control.Alternative.Free (Alt)
+import Data.Aeson ((.=), toJSON)
+import Data.Aeson qualified as JSON
+import Data.Set qualified as Set
+import Herald.Schema
+import Herald.OpenAPI (document)
+import Test.Hspec (Spec, describe, it, shouldBe)
+
+spec_examples ∷ Spec
+spec_examples = do
+  describe "scalar" do
+    it "simple" do
+      let model = boolean do
+            title "Test"
+
+      toJSON (document model) `shouldBe`
+        JSON.object
+          [ "title" .= JSON.String "Test"
+          , "type"  .= JSON.String "boolean"
+          ]
+
+    it "decorated" do
+      let model = string do
+            value
+              <* deprecated
+              <* forbid (Set.fromList [ "foo", "bar" ])
+              <* pattern "\\w+"
+
+      toJSON (document model) `shouldBe`
+        JSON.object
+          [ "deprecated" .= True
+          , "not" .= JSON.object
+              [ "enum" .= JSON.Array [ JSON.String "bar", JSON.String "foo" ]
+              ]
+
+          , "pattern" .= JSON.String "\\w+"
+          , "type" .= JSON.String "string"
+          ]
+
+    it "enumerated" do
+      let model = string do
+            allow [ ("foo", ()), ("bar", ()) ]
+              *> value
+
+      toJSON (document model) `shouldBe`
+        JSON.object
+          [ "enum" .= JSON.Array
+              [ JSON.String "bar"
+              , JSON.String "foo"
+              ]
+
+          , "type" .= JSON.String "string"
+          ]
+
+  describe "Composite" do
+    it "simple" do
+      toJSON (document (array value)) `shouldBe`
+        JSON.object
+          [ "type" .= JSON.String "array"
+          ]
+
+    it "decorated" do
+      let model = object do
+            x ← required "foo" $ string  value
+            y ← optional "bar" $ boolean value
+
+            pure (x, y)
+
+      toJSON (document model) `shouldBe`
+        JSON.object
+          [ "properties" .= JSON.object
+              [ "bar" .= JSON.object
+                  [ "type" .= JSON.String "boolean"
+                  ]
+
+              , "foo" .= JSON.object
+                  [ "type" .= JSON.String "string"
+                  ]
+              ]
+
+          , "required" .= JSON.Array [ JSON.String "foo" ]
+          , "type"     .= JSON.String "object"
+          ]
+
+    it "enumerated" do
+      let model ∷ Schema Alt ()
+          model = object $ allow
+            [ ( [ "foo" .= JSON.String "one"
+                , "bar" .= JSON.String "two"
+                ]
+              , ()
+              )
+
+            , ( [ "baz"  .= JSON.String "three"
+                , "quux" .= JSON.String "four"
+                ]
+              , ()
+              )
+            ]
+
+      toJSON (document model) `shouldBe`
+        JSON.object
+          [ "enum" .= JSON.Array
+              [ JSON.object
+                  [ "foo" .= JSON.String "one"
+                  , "bar" .= JSON.String "two"
+                  ]
+
+              , JSON.object
+                  [ "baz" .= JSON.String "three"
+                  , "quux" .= JSON.String "four"
+                  ]
+              ]
+
+          , "type" .= JSON.String "object"
+          ]


### PR DESCRIPTION
You can now call `document` on a schema structure, and you'll get back an OpenAPI specification in the form of a JSON object.