### PR TITLE
Add (orphan) `At`/`Ixed` instances for `aeson`'s `KeyMap`.

### DIFF
--- a/herald.cabal
+++ b/herald.cabal
@@ -24,6 +24,8 @@ library
   import: libraries
   default-language: GHC2021
   exposed-modules:
+    Data.Aeson.KeyMap.Extended
+
     Herald.Schema
     Herald.OpenAPI
   ghc-options: -Wall -Wextra -Wunused-packages

--- a/source/Data/Aeson/KeyMap/Extended.hs
+++ b/source/Data/Aeson/KeyMap/Extended.hs
@@ -1,0 +1,20 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UnicodeSyntax #-}
+
+-- |
+-- Orphan instances for lensing into key maps.
+module Data.Aeson.KeyMap.Extended where
+
+import Control.Lens
+import Data.Aeson.Key (Key)
+import Data.Aeson.KeyMap (KeyMap)
+import Data.Aeson.KeyMap qualified as KeyMap
+
+type instance Index   (KeyMap x) = Key
+type instance IxValue (KeyMap x) = x
+instance      Ixed    (KeyMap x)
+
+instance At (KeyMap x) where
+  at k f = KeyMap.alterF f k


### PR DESCRIPTION
Summarisation is lens-heavy, so these help a lot.